### PR TITLE
Fixed bug where reverse complement off-targets are missed in lower case reference. Fixes #51

### DIFF
--- a/guideseq/identifyOfftargetSites.py
+++ b/guideseq/identifyOfftargetSites.py
@@ -298,7 +298,7 @@ def processLine(line):
 
 
 def reverseComplement(sequence):
-    transtab = string.maketrans("ACGT", "TGCA")
+    transtab = string.maketrans("ACGTacgt", "TGCATGCA")
     return sequence.translate(transtab)[::-1]
 
 


### PR DESCRIPTION
Fixed bug where reverse complement off-targets are missed in lower case reference. 
Reported by Stacia Wyman.
Fixes #51